### PR TITLE
[noticket] Add possibility for inidividual asset paths

### DIFF
--- a/changelog/_unreleased/2020-09-14-Adjust-index-cleanup.md
+++ b/changelog/_unreleased/2020-09-14-Adjust-index-cleanup.md
@@ -1,0 +1,9 @@
+ ---
+ title:              Add customizable paths in plugin
+ issue:              
+ author:             Alexander Wink
+ author_email:       a.wink@kellerkinder.de
+ author_github:      @jinnoflife
+ ---
+ # Core
+ * Add customizable paths for storefront, admin, view and snippets 

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -24,6 +24,11 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 
 abstract class Bundle extends SymfonyBundle
 {
+    public const DEFAULT_PATH_VIEWS = 'Resources/views';
+    public const DEFAULT_PATH_SNIPPET = 'Resources/snippets';
+    public const DEFAULT_PATH_ADMINISTRATION = 'Resources/app/administration';
+    public const DEFAULT_PATH_STOREFRONT = 'Resources/app/storefront';
+
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
@@ -100,20 +105,27 @@ abstract class Bundle extends SymfonyBundle
         }
     }
 
-    /**
-     * @feature-deprecated tag:v6.4.0 - Implement `getActionEventClasses` instead
-     */
-    protected function getActionEvents(): array
+    public function getViewPaths(): array
     {
-        return [];
+        return [self::DEFAULT_PATH_VIEWS];
     }
 
-    /**
-     * Returns a list of all action event class references of this bundle. The events will be registered inside the `\Shopware\Core\Framework\Event\BusinessEventRegistry`.
-     *
-     * @return string[]
-     */
-    protected function getActionEventClasses(): array
+    public function getSnippetPath(): string
+    {
+        return self::DEFAULT_PATH_SNIPPET;
+    }
+
+    public function getAdministrationPath(): string
+    {
+        return self::DEFAULT_PATH_ADMINISTRATION;
+    }
+
+    public function getStorefrontPath(): string
+    {
+        return self::DEFAULT_PATH_STOREFRONT;
+    }
+
+    protected function getActionEvents(): array
     {
         return [];
     }
@@ -159,7 +171,6 @@ abstract class Bundle extends SymfonyBundle
     {
         $definition = $container->getDefinition(BusinessEventRegistry::class);
         $definition->addMethodCall('addMultiple', [$this->getActionEvents()]);
-        $definition->addMethodCall('addClasses', [$this->getActionEventClasses()]);
     }
 
     /**

--- a/src/Core/Framework/Plugin/BundleConfigGenerator.php
+++ b/src/Core/Framework/Plugin/BundleConfigGenerator.php
@@ -89,18 +89,18 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
 
             $bundles[$bundle->getName()] = [
                 'basePath' => $path . '/',
-                'views' => ['Resources/views'],
+                'views' => $bundle->getViewPaths(),
                 'technicalName' => str_replace('_', '-', $bundle->getContainerPrefix()),
                 'administration' => [
-                    'path' => 'Resources/app/administration/src',
-                    'entryFilePath' => $this->getEntryFile($bundle->getPath(), 'Resources/app/administration/src'),
-                    'webpack' => $this->getWebpackConfig($bundle->getPath(), 'Resources/app/administration'),
+                    'path' => $bundle->getAdministrationPath() . '/src',
+                    'entryFilePath' => $this->getEntryFile($bundle->getPath(), $bundle->getAdministrationPath() . '/src'),
+                    'webpack' => $this->getWebpackConfig($bundle->getPath(), $bundle->getAdministrationPath()),
                 ],
                 'storefront' => [
-                    'path' => 'Resources/app/storefront/src',
-                    'entryFilePath' => $this->getEntryFile($bundle->getPath(), 'Resources/app/storefront/src'),
-                    'webpack' => $this->getWebpackConfig($bundle->getPath(), 'Resources/app/storefront'),
-                    'styleFiles' => $this->getStyleFiles($bundle->getPath(), $bundle->getName()),
+                    'path' => $bundle->getStorefrontPath() . '/src',
+                    'entryFilePath' => $this->getEntryFile($bundle->getPath(), $bundle->getStorefrontPath() . '/src'),
+                    'webpack' => $this->getWebpackConfig($bundle->getPath(), $bundle->getStorefrontPath()),
+                    'styleFiles' => $this->getStyleFiles($bundle->getPath(), $bundle->getName(), $bundle->getStorefrontPath()),
                 ],
             ];
         }
@@ -143,7 +143,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
 
         return file_exists($absolutePath . '/main.ts') ? $path . '/main.ts'
             : (file_exists($absolutePath . '/main.js') ? $path . '/main.js'
-            : null);
+                : null);
     }
 
     private function getWebpackConfig(string $rootPath, string $componentPath): ?string
@@ -158,7 +158,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
         return $path . '/build/webpack.config.js';
     }
 
-    private function getStyleFiles(string $rootPath, string $technicalName): array
+    private function getStyleFiles(string $rootPath, string $technicalName, ?string $storefrontPath = Bundle::DEFAULT_PATH_STOREFRONT): array
     {
         $files = [];
         if ($this->kernel->getContainer()->has('Shopware\Storefront\Theme\StorefrontPluginRegistry')) {
@@ -171,7 +171,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
             }
         }
 
-        $path = $rootPath . DIRECTORY_SEPARATOR . 'Resources/app/storefront/src/scss';
+        $path = $rootPath . DIRECTORY_SEPARATOR . $storefrontPath . '/src/scss';
         if (is_dir($path)) {
             $finder = new Finder();
             $finder->in($path)->files()->depth(0);

--- a/src/Core/System/Snippet/Files/SnippetFileLoader.php
+++ b/src/Core/System/Snippet/Files/SnippetFileLoader.php
@@ -75,7 +75,7 @@ class SnippetFileLoader implements SnippetFileLoaderInterface
                 continue;
             }
 
-            $snippetDir = $bundle->getPath() . '/Resources/snippet';
+            $snippetDir = $bundle->getPath() . $bundle->getSnippetPath();
 
             if (!is_dir($snippetDir)) {
                 continue;


### PR DESCRIPTION
### 1. Why is this change necessary?
To set individual paths for bundles

### 2. What does this change do, exactly?
Allows the developer to set custom paths for administration/storefront and snippet paths

### 3. Describe each step to reproduce the issue or behaviour.
Try to

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
